### PR TITLE
Generalize functions to apply to stacks of images

### DIFF
--- a/moisan2011.py
+++ b/moisan2011.py
@@ -168,10 +168,7 @@ def per(u, inverse_dft=True, axes=(-2, -1)):
     """
     u = np.asarray(u, dtype=np.float64)
 
-    if axes == (-2, -1):
-        ut = u
-    else:
-        ut = np.moveaxis(u, axes, (-2, -1))
+    ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
 
@@ -251,10 +248,9 @@ def per2(u, inverse_dft=True, axes=(-2, -1)):
            Vision 39.2 (2011): 161-179.
            10.1007/s10851-010-0227-1. hal-00388020v2
     """
-    if axes == (-2, -1):
-        ut = u
-    else:
-        ut = np.moveaxis(u, axes, (-2, -1))
+    u = np.asarray(u, dtype=np.float64)
+
+    ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
 
@@ -336,10 +332,7 @@ def rper(u, inverse_dft=True, axes=(-2, -1)):
            10.1007/s10851-010-0227-1. hal-00388020v2
     """
     u = np.asarray(u, dtype=np.float64)
-    if axes == (-2, -1):
-        ut = u
-    else:
-        ut = np.moveaxis(u, axes, (-2, -1))
+    ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
 
@@ -407,7 +400,7 @@ def rper2(u, inverse_dft=True, axes=(-2, -1)):
 
     If inverse_dft is False, then the pair
 
-        (numpy.fft.rfft2(p axes=axes), numpy.fft.rfft2(s, axes=axes))
+        (numpy.fft.rfft2(p, axes=axes), numpy.fft.rfft2(s, axes=axes))
 
     is returned.
 
@@ -420,10 +413,8 @@ def rper2(u, inverse_dft=True, axes=(-2, -1)):
            Vision 39.2 (2011): 161-179.
            10.1007/s10851-010-0227-1. hal-00388020v2
     """
-    if axes == (-2, -1):
-        ut = u
-    else:
-        ut = np.moveaxis(u, axes, (-2, -1))
+    u = np.asarray(u, dtype=np.float64)
+    ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
 

--- a/moisan2011.py
+++ b/moisan2011.py
@@ -66,7 +66,7 @@ This is illustrated in the short example below:
 13.503994406832206
 """
 import numpy as np
-import scipy.ndimage
+import scipy.ndimage as ndi
 import scipy.sparse.linalg
 
 __author__ = 'Sebastien Brisard'
@@ -122,7 +122,28 @@ def _per(u, inverse_dft=True):
 
 
 def per(u, inverse_dft=True, axes=(-2, -1)):
-    """Compute the periodic component of the 2D image u.
+    """Compute the periodic component of the images u.
+
+    Parameters
+    ----------
+    u : array_like
+        Input image.
+    inverse_dft : boolean, optional
+        Whether to calculate the final inverse DFT or to forego
+        calcuation and to return the Fourier space representation
+        of the decomposition
+    axes : length-2 sequence of ints, optional
+        The axes along which to perform the tranformation.
+
+    Returns
+    -------
+    p : ndarray
+        Periodic component.
+    s : ndarray
+        Smooth component.
+
+    Notes
+    -----
 
     This function returns the periodic-plus-smooth decomposition of
     the array-like u along axes.
@@ -137,13 +158,19 @@ def per(u, inverse_dft=True, axes=(-2, -1)):
     is returned.
 
     This function implements Algorithm 1.
+
+    References
+    ----------
+    .. [1] Moisan, Lionel. "Periodic plus smooth image
+           decomposition." Journal of Mathematical Imaging and
+           Vision 39.2 (2011): 161-179.
+           10.1007/s10851-010-0227-1. hal-00388020v2
     """
     u = np.asarray(u, dtype=np.float64)
 
     if axes is (-2, -1):
         ut = u
     else:
-        print("per:", axes)
         ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
@@ -180,7 +207,28 @@ def per(u, inverse_dft=True, axes=(-2, -1)):
 
 
 def per2(u, inverse_dft=True, axes=(-2, -1)):
-    """Compute the periodic component of the 2D image u.
+    """Compute the periodic component of the image u.
+
+    Parameters
+    ----------
+    u : array_like
+        Input image.
+    inverse_dft : boolean, optional
+        Whether to calculate the final inverse DFT or to forego
+        calcuation and to return the Fourier space representation
+        of the decomposition
+    axes : length-2 sequence of ints, optional
+        The axes along which to perform the tranformation.
+
+    Returns
+    -------
+    p : ndarray
+        Periodic component.
+    s : ndarray
+        Smooth component.
+
+    Notes
+    -----
 
     This function returns the periodic-plus-smooth decomposition of
     the array-like u along axes.
@@ -195,11 +243,17 @@ def per2(u, inverse_dft=True, axes=(-2, -1)):
     is returned.
 
     This function implements Algorithm 2.
+
+    References
+    ----------
+    .. [1] Moisan, Lionel. "Periodic plus smooth image
+           decomposition." Journal of Mathematical Imaging and
+           Vision 39.2 (2011): 161-179.
+           10.1007/s10851-010-0227-1. hal-00388020v2
     """
     if axes is (-2, -1):
         ut = u
     else:
-        print("per2:", axes)
         ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
@@ -208,7 +262,7 @@ def per2(u, inverse_dft=True, axes=(-2, -1)):
                        [1.0, -4.0, 1.0],
                        [0.0, 1.0, 0.0]],
                       dtype=np.float64, ndmin=ut.ndim)
-    kp = scipy.ndimage.convolve(ut, kernel, mode='wrap')
+    kp = ndi.convolve(ut, kernel, mode='wrap')
 
     du = ut[..., -1, :] - ut[..., 0, :]
     kp[..., 0, :] -= du
@@ -225,7 +279,7 @@ def per2(u, inverse_dft=True, axes=(-2, -1)):
     k_dft = 2.0 * (cos_m[:, None]+cos_n[None, :]-2.0)
     k_dft[..., 0, 0] = 1.0
     p_dft = kp_dft / k_dft
-    p_dft[..., 0, 0] = ut.sum(axis=(-1,-2))
+    p_dft[..., 0, 0] = ut.sum(axis=(-1, -2))
 
     if inverse_dft:
         p = np.fft.ifft2(p_dft)
@@ -237,7 +291,28 @@ def per2(u, inverse_dft=True, axes=(-2, -1)):
 
 
 def rper(u, inverse_dft=True, axes=(-2, -1)):
-    """Compute the periodic component of the 2D, real image u.
+    """Compute the periodic component of the real image u.
+
+    Parameters
+    ----------
+    u : array_like
+        Input image, assumed to be real-valued
+    inverse_dft : boolean, optional
+        Whether to calculate the final inverse DFT or to forego
+        calcuation and to return the Fourier space representation
+        of the decomposition
+    axes : length-2 sequence of ints, optional
+        The axes along which to perform the tranformation.
+
+    Returns
+    -------
+    p : ndarray
+        Periodic component.
+    s : ndarray
+        Smooth component.
+
+    Notes
+    -----
 
     This function returns the periodic-plus-smooth decomposition of
     the 2D array-like u. The image must be real.
@@ -247,17 +322,23 @@ def rper(u, inverse_dft=True, axes=(-2, -1)):
 
     If inverse_dft is False, then the pair
 
-        (numpy.fft.rfft2(p), numpy.fft.rfft2(s))
+        (numpy.fft.rfft2(p, axes=axes), numpy.fft.rfft2(s, axes=axes))
 
     is returned.
 
     This function implements Algorithm 1.
+
+    References
+    ----------
+    .. [1] Moisan, Lionel. "Periodic plus smooth image
+           decomposition." Journal of Mathematical Imaging and
+           Vision 39.2 (2011): 161-179.
+           10.1007/s10851-010-0227-1. hal-00388020v2
     """
     u = np.asarray(u, dtype=np.float64)
     if axes is (-2, -1):
         ut = u
     else:
-        print("rper:", axes)
         ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
@@ -285,7 +366,7 @@ def rper(u, inverse_dft=True, axes=(-2, -1)):
     s_dft[..., 0, 0] = 0.0
 
     if inverse_dft:
-        s = np.fft.irfft2(s_dft, (m,n))
+        s = np.fft.irfft2(s_dft, (m, n))
         s = np.moveaxis(s, (-2, -1), axes)
         return u - s, s
     else:
@@ -297,6 +378,27 @@ def rper(u, inverse_dft=True, axes=(-2, -1)):
 def rper2(u, inverse_dft=True, axes=(-2, -1)):
     """Compute the periodic component of the real images u.
 
+    Parameters
+    ----------
+    u : array_like
+        Input image, assumed to be real-valued
+    inverse_dft : boolean, optional
+        Whether to calculate the final inverse DFT or to forego
+        calcuation and to return the Fourier space representation
+        of the decomposition
+    axes : length-2 sequence of ints, optional
+        The axes along which to perform the tranformation.
+
+    Returns
+    -------
+    p : ndarray
+        Periodic component.
+    s : ndarray
+        Smooth component.
+
+    Notes
+    -----
+
     This function returns the periodic-plus-smooth decomposition of
     the array-like u along axes. The images must be real.
 
@@ -305,16 +407,22 @@ def rper2(u, inverse_dft=True, axes=(-2, -1)):
 
     If inverse_dft is False, then the pair
 
-        (numpy.fft.rfft2(p), numpy.fft.rfft2(s))
+        (numpy.fft.rfft2(p axes=axes), numpy.fft.rfft2(s, axes=axes))
 
     is returned.
 
     This function implements Algorithm 2.
+
+    References
+    ----------
+    .. [1] Moisan, Lionel. "Periodic plus smooth image
+           decomposition." Journal of Mathematical Imaging and
+           Vision 39.2 (2011): 161-179.
+           10.1007/s10851-010-0227-1. hal-00388020v2
     """
     if axes is (-2, -1):
         ut = u
     else:
-        print("rper2:", axes)
         ut = np.moveaxis(u, axes, (-2, -1))
 
     m, n = ut.shape[-2:]
@@ -323,7 +431,7 @@ def rper2(u, inverse_dft=True, axes=(-2, -1)):
                        [1.0, -4.0, 1.0],
                        [0.0, 1.0, 0.0]],
                       dtype=np.float64, ndmin=ut.ndim)
-    kp = scipy.ndimage.convolve(ut, kernel, mode='wrap')
+    kp = ndi.convolve(ut, kernel, mode='wrap')
 
     du = ut[..., -1, :] - ut[..., 0, :]
     kp[..., 0, :] -= du
@@ -343,12 +451,11 @@ def rper2(u, inverse_dft=True, axes=(-2, -1)):
     p_dft[..., 0, 0] = ut.sum(axis=(-2, -1))
 
     if inverse_dft:
-        p = np.fft.irfft2(p_dft, (m,n))
+        p = np.fft.irfft2(p_dft, (m, n))
         p = np.moveaxis(p, (-2, -1), axes)
         return p, u - p
     else:
         p_dft = np.moveaxis(p_dft, (-2, -1), axes)
-        print("rper2shape", p_dft.shape, u.shape, np.fft.rfft2(u, axes=axes).shape)
         return p_dft, np.fft.rfft2(u, axes=axes) - p_dft
 
 
@@ -520,7 +627,7 @@ class OperatorQ(ImageLinearOperator):
         if y is None:
             y = np.zeros_like(x)
 
-        scipy.ndimage.convolve(x, self.kernel, output=y, mode='wrap')
+        ndi.convolve(x, self.kernel, output=y, mode='wrap')
         return y+x.mean()/self.shape[0]
 
     def _adjoint(self):

--- a/moisan2011.py
+++ b/moisan2011.py
@@ -121,11 +121,11 @@ def _per(u, inverse_dft=True):
         return u_dft-s_dft, s_dft
 
 
-def per(u, inverse_dft=True):
+def per(u, inverse_dft=True, axes=(-2, -1)):
     """Compute the periodic component of the 2D image u.
 
     This function returns the periodic-plus-smooth decomposition of
-    the 2D array-like u.
+    the array-like u along axes.
 
     If inverse_dft is True, then the pair (p, s) is returned
     (p: periodic component; s: smooth component).
@@ -140,7 +140,13 @@ def per(u, inverse_dft=True):
     """
     u = np.asarray(u, dtype=np.float64)
 
-    m, n = u.shape
+    if axes is (-2, -1):
+        ut = u
+    else:
+        print("per:", axes)
+        ut = np.moveaxis(u, axes, (-2, -1))
+
+    m, n = ut.shape[-2:]
 
     arg = 2.*np.pi*np.fft.fftfreq(m, 1.)
     cos_m, sin_m = np.cos(arg), np.sin(arg)
@@ -150,32 +156,34 @@ def per(u, inverse_dft=True):
     cos_n, sin_n = np.cos(arg), np.sin(arg)
     one_minus_exp_n = 1.0-cos_n-1j*sin_n
 
-    w1 = u[:, -1]-u[:, 0]
+    w1 = ut[..., -1] - ut[..., 0]
     w1_dft = np.fft.fft(w1)
-    v_dft = w1_dft[:, None]*one_minus_exp_n[None, :]
+    v_dft = w1_dft[..., None] * one_minus_exp_n[..., None, :]
 
-    w2 = u[-1, :]-u[0, :]
+    w2 = ut[..., -1, :] - ut[..., 0, :]
     w2_dft = np.fft.fft(w2)
-    v_dft += one_minus_exp_m[:, None]*w2_dft[None, :]
+    v_dft += one_minus_exp_m[..., None]*w2_dft[..., None, :]
 
     denom = 2.0*(cos_m[:, None]+cos_n[None, :]-2.0)
-    denom[0, 0] = 1.0
+    denom[..., 0, 0] = 1.0
     s_dft = v_dft/denom
-    s_dft[0, 0] = 0.0
+    s_dft[..., 0, 0] = 0.0
 
     if inverse_dft:
         s = np.fft.ifft2(s_dft)
+        s = np.moveaxis(s, (-2, -1), axes)
         return u-s, s
     else:
-        u_dft = np.fft.fft2(u)
+        u_dft = np.fft.fft2(u, axes=axes)
+        s_dft = np.moveaxis(s_dft, (-2, -1), axes)
         return u_dft-s_dft, s_dft
 
 
-def per2(u, inverse_dft=True):
+def per2(u, inverse_dft=True, axes=(-2, -1)):
     """Compute the periodic component of the 2D image u.
 
     This function returns the periodic-plus-smooth decomposition of
-    the 2D array-like u.
+    the array-like u along axes.
 
     If inverse_dft is True, then the pair (p, s) is returned
     (p: periodic component; s: smooth component).
@@ -188,39 +196,47 @@ def per2(u, inverse_dft=True):
 
     This function implements Algorithm 2.
     """
-    u = np.asarray(u, dtype=np.float64)
-    m, n = u.shape
+    if axes is (-2, -1):
+        ut = u
+    else:
+        print("per2:", axes)
+        ut = np.moveaxis(u, axes, (-2, -1))
+
+    m, n = ut.shape[-2:]
 
     kernel = np.array([[0.0, 1.0, 0.0],
                        [1.0, -4.0, 1.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
-    kp = scipy.ndimage.convolve(u, kernel, mode='wrap')
+                       [0.0, 1.0, 0.0]],
+                      dtype=np.float64, ndmin=ut.ndim)
+    kp = scipy.ndimage.convolve(ut, kernel, mode='wrap')
 
-    du = u[-1, :]-u[0, :]
-    kp[0, :] -= du
-    kp[-1, :] += du
+    du = ut[..., -1, :] - ut[..., 0, :]
+    kp[..., 0, :] -= du
+    kp[..., -1, :] += du
 
-    du = u[:, -1]-u[:, 0]
-    kp[:, 0] -= du
-    kp[:, -1] += du
+    du = ut[..., -1] - ut[..., 0]
+    kp[..., 0] -= du
+    kp[..., -1] += du
 
     kp_dft = np.fft.fft2(kp)
 
-    cos_m = np.cos(2.*np.pi*np.fft.fftfreq(m, 1.))
-    cos_n = np.cos(2.*np.pi*np.fft.fftfreq(n, 1.))
-    k_dft = 2.0*(cos_m[:, None]+cos_n[None, :]-2.0)
-    k_dft[0, 0] = 1.0
-    p_dft = kp_dft/k_dft
-    p_dft[0, 0] = u.sum()
+    cos_m = np.cos(2. * np.pi * np.fft.fftfreq(m, 1.))
+    cos_n = np.cos(2. * np.pi * np.fft.fftfreq(n, 1.))
+    k_dft = 2.0 * (cos_m[:, None]+cos_n[None, :]-2.0)
+    k_dft[..., 0, 0] = 1.0
+    p_dft = kp_dft / k_dft
+    p_dft[..., 0, 0] = ut.sum(axis=(-1,-2))
 
     if inverse_dft:
         p = np.fft.ifft2(p_dft)
-        return p, u-p
+        p = np.moveaxis(p, (-2, -1), axes)
+        return p, u - p
     else:
-        return p_dft, np.fft.fft2(u)-p_dft
+        p_dft = np.moveaxis(p_dft, (-2, -1), axes)
+        return p_dft, np.fft.fft2(u, axes=axes) - p_dft
 
 
-def rper(u, inverse_dft=True):
+def rper(u, inverse_dft=True, axes=(-2, -1)):
     """Compute the periodic component of the 2D, real image u.
 
     This function returns the periodic-plus-smooth decomposition of
@@ -238,43 +254,51 @@ def rper(u, inverse_dft=True):
     This function implements Algorithm 1.
     """
     u = np.asarray(u, dtype=np.float64)
-    m, n = u.shape
+    if axes is (-2, -1):
+        ut = u
+    else:
+        print("rper:", axes)
+        ut = np.moveaxis(u, axes, (-2, -1))
 
-    arg = 2.*np.pi*np.fft.fftfreq(m, 1.)
+    m, n = ut.shape[-2:]
+
+    arg = 2.*np.pi * np.fft.fftfreq(m, 1.)
     cos_m, sin_m = np.cos(arg), np.sin(arg)
-    one_minus_exp_m = 1.0-cos_m-1j*sin_m
+    one_minus_exp_m = 1.0 - cos_m - 1j*sin_m
 
-    arg = 2.*np.pi*np.fft.rfftfreq(n, 1.)
+    arg = 2.*np.pi * np.fft.rfftfreq(n, 1.)
     cos_n, sin_n = np.cos(arg), np.sin(arg)
-    one_minus_exp_n = 1.0-cos_n-1j*sin_n
+    one_minus_exp_n = 1.0 - cos_n - 1j*sin_n
 
-    w1 = u[:, -1]-u[:, 0]
-    w1_dft = np.fft.fft(w1)
+    w1 = ut[..., -1] - ut[..., 0]
     # Use complex fft because irfft2 needs all modes in the first direction
-    v1_dft = w1_dft[:, None]*one_minus_exp_n[None, :]
+    w1_dft = np.fft.fft(w1)
+    v1_dft = w1_dft[..., None] * one_minus_exp_n[..., None, :]
 
-    w2 = u[-1, :]-u[0, :]
+    w2 = ut[..., -1, :] - ut[..., 0, :]
     w2_dft = np.fft.rfft(w2)
-    v2_dft = one_minus_exp_m[:, None]*w2_dft[None, :]
+    v2_dft = one_minus_exp_m[..., None]*w2_dft[..., None, :]
 
-    k_dft = 2.0*(cos_m[:, None]+cos_n[None, :]-2.0)
-    k_dft[0, 0] = 1.0
-    s_dft = (v1_dft+v2_dft)/k_dft
-    s_dft[0, 0] = 0.0
+    k_dft = 2.0 * (cos_m[:, None]+cos_n[None, :]-2.0)
+    k_dft[..., 0, 0] = 1.0
+    s_dft = (v1_dft+v2_dft) / k_dft
+    s_dft[..., 0, 0] = 0.0
 
     if inverse_dft:
-        s = np.fft.irfft2(s_dft, u.shape)
-        return u-s, s
+        s = np.fft.irfft2(s_dft, (m,n))
+        s = np.moveaxis(s, (-2, -1), axes)
+        return u - s, s
     else:
-        u_dft = np.fft.rfft2(u)
+        u_dft = np.fft.rfft2(u, axes=axes)
+        s_dft = np.moveaxis(s_dft, (-2, -1), axes)
         return u_dft-s_dft, s_dft
 
 
-def rper2(u, inverse_dft=True):
-    """Compute the periodic component of the 2D, real image u.
+def rper2(u, inverse_dft=True, axes=(-2, -1)):
+    """Compute the periodic component of the real images u.
 
     This function returns the periodic-plus-smooth decomposition of
-    the 2D array-like u. The image must be real.
+    the array-like u along axes. The images must be real.
 
     If inverse_dft is True, then the pair (p, s) is returned
     (p: periodic component; s: smooth component).
@@ -287,36 +311,45 @@ def rper2(u, inverse_dft=True):
 
     This function implements Algorithm 2.
     """
-    u = np.asarray(u, dtype=np.float64)
-    m, n = u.shape
+    if axes is (-2, -1):
+        ut = u
+    else:
+        print("rper2:", axes)
+        ut = np.moveaxis(u, axes, (-2, -1))
+
+    m, n = ut.shape[-2:]
 
     kernel = np.array([[0.0, 1.0, 0.0],
                        [1.0, -4.0, 1.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
-    kp = scipy.ndimage.convolve(u, kernel, mode='wrap')
+                       [0.0, 1.0, 0.0]],
+                      dtype=np.float64, ndmin=ut.ndim)
+    kp = scipy.ndimage.convolve(ut, kernel, mode='wrap')
 
-    du = u[-1, :]-u[0, :]
-    kp[0, :] -= du
-    kp[-1, :] += du
+    du = ut[..., -1, :] - ut[..., 0, :]
+    kp[..., 0, :] -= du
+    kp[..., -1, :] += du
 
-    du = u[:, -1]-u[:, 0]
-    kp[:, 0] -= du
-    kp[:, -1] += du
+    du = ut[..., -1] - ut[..., 0]
+    kp[..., 0] -= du
+    kp[..., -1] += du
 
     kp_dft = np.fft.rfft2(kp)
 
-    cos_m = np.cos(2.*np.pi*np.fft.fftfreq(m, 1.))
-    cos_n = np.cos(2.*np.pi*np.fft.rfftfreq(n, 1.))
-    k_dft = 2.0*(cos_m[:, None]+cos_n[None, :]-2.0)
-    k_dft[0, 0] = 1.0
-    p_dft = kp_dft/k_dft
-    p_dft[0, 0] = u.sum()
+    cos_m = np.cos(2. * np.pi * np.fft.fftfreq(m, 1.))
+    cos_n = np.cos(2. * np.pi * np.fft.rfftfreq(n, 1.))
+    k_dft = 2.0 * (cos_m[:, None]+cos_n[None, :]-2.0)
+    k_dft[..., 0, 0] = 1.0
+    p_dft = kp_dft / k_dft
+    p_dft[..., 0, 0] = ut.sum(axis=(-2, -1))
 
     if inverse_dft:
-        p = np.fft.irfft2(p_dft, u.shape)
-        return p, u-p
+        p = np.fft.irfft2(p_dft, (m,n))
+        p = np.moveaxis(p, (-2, -1), axes)
+        return p, u - p
     else:
-        return p_dft, np.fft.rfft2(u)-p_dft
+        p_dft = np.moveaxis(p_dft, (-2, -1), axes)
+        print("rper2shape", p_dft.shape, u.shape, np.fft.rfft2(u, axes=axes).shape)
+        return p_dft, np.fft.rfft2(u, axes=axes) - p_dft
 
 
 def ssd(a, b):

--- a/moisan2011.py
+++ b/moisan2011.py
@@ -168,7 +168,7 @@ def per(u, inverse_dft=True, axes=(-2, -1)):
     """
     u = np.asarray(u, dtype=np.float64)
 
-    if axes is (-2, -1):
+    if axes == (-2, -1):
         ut = u
     else:
         ut = np.moveaxis(u, axes, (-2, -1))
@@ -251,7 +251,7 @@ def per2(u, inverse_dft=True, axes=(-2, -1)):
            Vision 39.2 (2011): 161-179.
            10.1007/s10851-010-0227-1. hal-00388020v2
     """
-    if axes is (-2, -1):
+    if axes == (-2, -1):
         ut = u
     else:
         ut = np.moveaxis(u, axes, (-2, -1))
@@ -336,7 +336,7 @@ def rper(u, inverse_dft=True, axes=(-2, -1)):
            10.1007/s10851-010-0227-1. hal-00388020v2
     """
     u = np.asarray(u, dtype=np.float64)
-    if axes is (-2, -1):
+    if axes == (-2, -1):
         ut = u
     else:
         ut = np.moveaxis(u, axes, (-2, -1))
@@ -420,7 +420,7 @@ def rper2(u, inverse_dft=True, axes=(-2, -1)):
            Vision 39.2 (2011): 161-179.
            10.1007/s10851-010-0227-1. hal-00388020v2
     """
-    if axes is (-2, -1):
+    if axes == (-2, -1):
         ut = u
     else:
         ut = np.moveaxis(u, axes, (-2, -1))

--- a/test_moisan2011.py
+++ b/test_moisan2011.py
@@ -59,6 +59,7 @@ def real_images():
     return [np.ascontiguousarray(u[:m, :n])
             for m, n in itertools.product([m0-1, m0], [n0-1, n0])]
 
+
 def real_image_stacks():
     im_list = real_images()
     return [np.array([im]*3) for im in im_list]
@@ -138,22 +139,22 @@ def test_consistency(per, u, inverse_dft):
     assert_allclose(s_act, s_exp, eps, eps)
 
 
-@pytest.mark.parametrize('per, u, axes, inverse_dft', 
-                         itertools.product((op for op in operators() if op != moisan2011._per), 
-                                            real_image_stacks(),
-                                            [(-1, -2), (0, 1)], [True, False]))
+@pytest.mark.parametrize('per, u, axes, inverse_dft',
+                         itertools.product((op for op in operators()
+                                            if op != moisan2011._per),
+                                           real_image_stacks(),
+                                           [(-1, -2), (0, 1)],
+                                           [True, False]))
 def test_nd(per, u, axes, inverse_dft):
     eps = {moisan2011.per: 1E-11,
            moisan2011.per2: 1E-9,
            moisan2011.rper: 1E-10,
            moisan2011.rper2: 1E-9}[per]
-    print("test_nd", axes, "inverse", inverse_dft)
-    ut = np.moveaxis(u, (-2,-1), axes)
+    ut = np.moveaxis(u, (-2, -1), axes)
     ps, ss = per(ut, inverse_dft, axes)
-    ps = np.moveaxis(ps, axes, (-2,-1))
-    ss = np.moveaxis(ss, axes, (-2,-1))
-    for p,s,u in zip(ps, ss, u):
+    ps = np.moveaxis(ps, axes, (-2, -1))
+    ss = np.moveaxis(ss, axes, (-2, -1))
+    for p, s, u in zip(ps, ss, u):
         p_exp, s_exp = per(u, inverse_dft)
         assert_allclose(p_exp, p, eps, eps)
         assert_allclose(s_exp, s, eps, eps)
-

--- a/test_moisan2011.py
+++ b/test_moisan2011.py
@@ -59,6 +59,10 @@ def real_images():
     return [np.ascontiguousarray(u[:m, :n])
             for m, n in itertools.product([m0-1, m0], [n0-1, n0])]
 
+def real_image_stacks():
+    im_list = real_images()
+    return [np.array([im]*3) for im in im_list]
+
 
 def operators_and_real_images():
     return itertools.product(complex_operators(), real_images())
@@ -132,3 +136,24 @@ def test_consistency(per, u, inverse_dft):
     p_act, s_act = per(u, inverse_dft=inverse_dft)
     assert_allclose(p_act, p_exp, eps, eps)
     assert_allclose(s_act, s_exp, eps, eps)
+
+
+@pytest.mark.parametrize('per, u, axes, inverse_dft', 
+                         itertools.product((op for op in operators() if op != moisan2011._per), 
+                                            real_image_stacks(),
+                                            [(-1, -2), (0, 1)], [True, False]))
+def test_nd(per, u, axes, inverse_dft):
+    eps = {moisan2011.per: 1E-11,
+           moisan2011.per2: 1E-9,
+           moisan2011.rper: 1E-10,
+           moisan2011.rper2: 1E-9}[per]
+    print("test_nd", axes, "inverse", inverse_dft)
+    ut = np.moveaxis(u, (-2,-1), axes)
+    ps, ss = per(ut, inverse_dft, axes)
+    ps = np.moveaxis(ps, axes, (-2,-1))
+    ss = np.moveaxis(ss, axes, (-2,-1))
+    for p,s,u in zip(ps, ss, u):
+        p_exp, s_exp = per(u, inverse_dft)
+        assert_allclose(p_exp, p, eps, eps)
+        assert_allclose(s_exp, s, eps, eps)
+


### PR DESCRIPTION
In anticipation of an attempt to get this work into skimage, I wrote an extension to make the functions applicable to stacks of images. 

By adding an axes parameter to all flavors of the per operator.
Note: This still only applies the transform to 2D slices of the nD array
and is no true generalization to N-dimensional datasets (the original
paper does not treat the nD case, although the extension seems
straightforward mathematically.

As a next step I will update the docstring to conform to the NumPy standard, if it is desirable I can add that to this same pull request.